### PR TITLE
Add option for specifying encoding

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 * Support for Gradle 6.8.x
 * Early support for Gradle 7
+* Add option 'encoding' for generated classes
 
 == [1.0.0-rc.1] - 2020-12-13
 

--- a/cxf-codegen-gradle/src/main/java/io/mateo/cxf/codegen/wsdl2java/Option.java
+++ b/cxf-codegen-gradle/src/main/java/io/mateo/cxf/codegen/wsdl2java/Option.java
@@ -258,6 +258,13 @@ public interface Option extends GenericWsdlOption {
 	Property<Boolean> getAllowElementRefs();
 
 	/**
+	 * Sets the encoding for the generated files. This option has been added in CXF
+	 * version 2.5.4.
+	 * @return encoding indicator
+	 */
+	Property<String> getEncoding();
+
+	/**
 	 * Enables or disables verbosity.
 	 * @return verbosity indicator
 	 */

--- a/cxf-codegen-gradle/src/main/java/io/mateo/cxf/codegen/wsdl2java/WsdlOption.java
+++ b/cxf-codegen-gradle/src/main/java/io/mateo/cxf/codegen/wsdl2java/WsdlOption.java
@@ -96,6 +96,8 @@ public class WsdlOption implements Option, Named {
 
 	private final Property<Boolean> allowElementRefs;
 
+	private final Property<String> encoding;
+
 	private final Property<Boolean> verbose;
 
 	private final DirectoryProperty outputDir;
@@ -136,6 +138,7 @@ public class WsdlOption implements Option, Named {
 		this.autoNameResolution = objects.property(Boolean.class);
 		this.noAddressBinding = objects.property(Boolean.class);
 		this.allowElementRefs = objects.property(Boolean.class);
+		this.encoding = objects.property(String.class);
 		this.verbose = objects.property(Boolean.class);
 	}
 
@@ -374,6 +377,13 @@ public class WsdlOption implements Option, Named {
 	/**
 	 * {@inheritDoc}
 	 */
+	public Property<String> getEncoding() {
+		return this.encoding;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public Property<Boolean> getVerbose() {
 		return this.verbose;
@@ -504,6 +514,10 @@ public class WsdlOption implements Option, Named {
 		}
 		if (this.wsdlList.isPresent() && this.wsdlList.get()) {
 			command.add("-wsdlList");
+		}
+		if(this.encoding.isPresent()) {
+			command.add("-encoding");
+			command.add(this.encoding.get());
 		}
 		if (this.verbose.isPresent() && this.verbose.get()) {
 			command.add("-verbose");

--- a/cxf-codegen-gradle/src/main/java/io/mateo/cxf/codegen/wsdl2java/WsdlOption.java
+++ b/cxf-codegen-gradle/src/main/java/io/mateo/cxf/codegen/wsdl2java/WsdlOption.java
@@ -515,7 +515,7 @@ public class WsdlOption implements Option, Named {
 		if (this.wsdlList.isPresent() && this.wsdlList.get()) {
 			command.add("-wsdlList");
 		}
-		if(this.encoding.isPresent()) {
+		if (this.encoding.isPresent()) {
 			command.add("-encoding");
 			command.add(this.encoding.get());
 		}

--- a/cxf-codegen-gradle/src/test/java/io/mateo/cxf/codegen/wsdl2java/WsdlOptionTests.java
+++ b/cxf-codegen-gradle/src/test/java/io/mateo/cxf/codegen/wsdl2java/WsdlOptionTests.java
@@ -324,7 +324,7 @@ class WsdlOptionTests {
 	void encoding() {
 		this.option.getEncoding().set("UTF-8");
 		List<String> expected = List.of("-d", this.outputDir.getAbsolutePath(), "-encoding", "UTF-8",
-										this.temp.toURI().toString());
+				this.temp.toURI().toString());
 
 		List<String> actual = this.option.generateArgs();
 

--- a/cxf-codegen-gradle/src/test/java/io/mateo/cxf/codegen/wsdl2java/WsdlOptionTests.java
+++ b/cxf-codegen-gradle/src/test/java/io/mateo/cxf/codegen/wsdl2java/WsdlOptionTests.java
@@ -321,6 +321,17 @@ class WsdlOptionTests {
 	}
 
 	@Test
+	void encoding() {
+		this.option.getEncoding().set("UTF-8");
+		List<String> expected = List.of("-d", this.outputDir.getAbsolutePath(), "-encoding", "UTF-8",
+										this.temp.toURI().toString());
+
+		List<String> actual = this.option.generateArgs();
+
+		assertThat(actual).containsExactlyElementsOf(expected);
+	}
+
+	@Test
 	void verbose() {
 		this.option.getVerbose().set(true);
 		List<String> expected = List.of("-d", this.outputDir.getAbsolutePath(), "-verbose",


### PR DESCRIPTION
Apache CXF has an uncodumented encoding parameter (see [here](https://stackoverflow.com/questions/12180231/wsdl2java-generated-code-causes-character-encoding-problems)). This parameter can fix builds if they contain special characters. With this PR, the encoding parameter is forwarded to Apache CXF.