### PR TITLE
Make Wsdl2JavaTask @CacheableTask, determine @InputFiles, register tasks in extension

### DIFF
--- a/cxf-codegen-gradle/build.gradle.kts
+++ b/cxf-codegen-gradle/build.gradle.kts
@@ -46,6 +46,8 @@ configurations {
 }
 
 dependencies {
+    implementation("wsdl4j:wsdl4j:1.6.3")
+
     "functionalTestImplementation"("commons-io:commons-io")
 }
 

--- a/cxf-codegen-gradle/src/functionalTest/java/docs/GeneratingJavaFunctionalTests.java
+++ b/cxf-codegen-gradle/src/functionalTest/java/docs/GeneratingJavaFunctionalTests.java
@@ -47,7 +47,7 @@ class GeneratingJavaFunctionalTests {
 
 	@TestTemplate
 	void disableAllLogs(GradleBuild gradleBuild) throws IOException {
-		GradleRunner runner = gradleBuild.script(scriptFor("disable-all-logs")).prepareRunner("wsdl2java");
+		GradleRunner runner = gradleBuild.script(scriptFor("disable-all-logs")).prepareRunnerDebug("wsdl2java");
 		FileUtils.copyFile(new File("src/functionalTest/resources/emptyLogback.xml"),
 				new File(gradleBuild.getProjectDir(), "logback.xml"));
 		FileUtils.moveFile(FileUtils.getFile(gradleBuild.getProjectDir(), "wsdls/calculator.wsdl"),
@@ -63,7 +63,7 @@ class GeneratingJavaFunctionalTests {
 
 	@TestTemplate
 	void disableLogs(GradleBuild gradleBuild) throws IOException {
-		GradleRunner runner = gradleBuild.script(scriptFor("disable-logs")).prepareRunner("wsdl2java");
+		GradleRunner runner = gradleBuild.script(scriptFor("disable-logs")).prepareRunnerDebug("wsdl2java");
 
 		BuildResult result = runner.build();
 
@@ -73,14 +73,14 @@ class GeneratingJavaFunctionalTests {
 
 	@TestTemplate
 	void javaNine(GradleBuild gradleBuild) {
-		BuildResult result = gradleBuild.script(scriptFor("java-nine")).prepareRunner("verify").build();
+		BuildResult result = gradleBuild.script(scriptFor("java-nine")).prepareRunnerDebug("verify").build();
 
 		assertThat(result.getOutput()).contains(List.of("jakarta.xml.ws-api", "jakarta.annotation-api"));
 	}
 
 	@TestTemplate
 	void logging(GradleBuild gradleBuild) {
-		BuildResult result = gradleBuild.script(scriptFor("logging")).prepareRunner("wsdl2java").build();
+		BuildResult result = gradleBuild.script(scriptFor("logging")).prepareRunnerDebug("wsdl2java").build();
 
 		assertThat(result.getOutput()).contains("DEBUG org.apache.cxf.common.logging.LogUtils",
 				"DEBUG org.apache.cxf.tools.wsdlto.core.PluginLoader", "DEBUG org.apache.velocity");
@@ -88,14 +88,14 @@ class GeneratingJavaFunctionalTests {
 
 	@TestTemplate
 	void minimalUsage(GradleBuild gradleBuild) {
-		BuildResult result = gradleBuild.script(scriptFor("minimal-usage")).prepareRunner("verify").build();
+		BuildResult result = gradleBuild.script(scriptFor("minimal-usage")).prepareRunnerDebug("verify").build();
 
 		assertThat(result.getOutput()).contains("/path/to/example.wsdl");
 	}
 
 	@TestTemplate
 	void options(GradleBuild gradleBuild) {
-		BuildResult result = gradleBuild.script(scriptFor("options")).prepareRunner("verify").build();
+		BuildResult result = gradleBuild.script(scriptFor("options")).prepareRunnerDebug("verify").build();
 
 		assertThat(result.getOutput()).contains("/path/to/example.wsdl", "/build/generated-java", "markGenerated=true",
 				"packageNames=[com.example, com.foo.bar]", "asyncMethods=[foo, bar]");

--- a/cxf-codegen-gradle/src/functionalTest/java/io/mateo/cxf/codegen/AdditionalPluginsFunctionalTests.java
+++ b/cxf-codegen-gradle/src/functionalTest/java/io/mateo/cxf/codegen/AdditionalPluginsFunctionalTests.java
@@ -41,7 +41,7 @@ class AdditionalPluginsFunctionalTests {
 
 	@TestTemplate // gh-7
 	void micronautApplicationPlugin(GradleBuild gradleBuild) {
-		GradleRunner runner = gradleBuild.prepareRunner("wsdl2java", "-i", "-PmicronautVersion=2.0.1");
+		GradleRunner runner = gradleBuild.prepareRunnerDebug("wsdl2java", "-i", "-PmicronautVersion=2.0.1");
 
 		BuildResult result = runner.build();
 

--- a/cxf-codegen-gradle/src/functionalTest/java/io/mateo/cxf/codegen/ConfigurationCacheFunctionalTests.java
+++ b/cxf-codegen-gradle/src/functionalTest/java/io/mateo/cxf/codegen/ConfigurationCacheFunctionalTests.java
@@ -33,7 +33,7 @@ class ConfigurationCacheFunctionalTests {
 
 	@TestTemplate
 	void configurationCache(GradleBuild gradleBuild) {
-		GradleRunner runner = gradleBuild.prepareRunner("--configuration-cache", "wsdl2javaCalculator");
+		GradleRunner runner = gradleBuild.prepareRunnerDebug("--configuration-cache", "wsdl2javaCalculator");
 
 		BuildResult initialResult = runner.build();
 		BuildResult finalResult = runner.build();

--- a/cxf-codegen-gradle/src/functionalTest/java/io/mateo/cxf/codegen/IncrementalBuildFunctionalTests.java
+++ b/cxf-codegen-gradle/src/functionalTest/java/io/mateo/cxf/codegen/IncrementalBuildFunctionalTests.java
@@ -17,9 +17,15 @@ package io.mateo.cxf.codegen;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
 import io.mateo.junit.GradleBuild;
 import io.mateo.junit.GradleCompatibility;
 
+import org.apache.commons.io.FileUtils;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.TestTemplate;
@@ -28,25 +34,60 @@ import org.junit.jupiter.api.TestTemplate;
 class IncrementalBuildFunctionalTests {
 
 	@TestTemplate
-	void separateXsd(GradleBuild gradleBuild) {
-		doTest(gradleBuild);
+	void separateXsd(GradleBuild gradleBuild) throws IOException {
+		{
+			// test that a change in the WSDL referencing another XSD trigger a rebuild
+			GradleRunner runner = gradleBuild.prepareRunner("wsdl2javaCalculator", "-i");
+			runner.build();
+
+			String addJavaBefore = FileUtils.readFileToString(
+					new File(runner.getProjectDir(), "build/generated-sources/org/tempuri/Add.java"), "UTF-8");
+			assertThat(addJavaBefore).doesNotContain("protected int intC;");
+
+			FileUtils.copyFile(new File("src/functionalTest/resources/wsdls/calculatorSeparateXsdModified.wsdl"),
+					new File(runner.getProjectDir(), "wsdls/calculatorSeparateXsd.wsdl"));
+
+			BuildResult finalResult = runner.build();
+			assertThat(finalResult.getOutput()).contains("Task ':wsdl2javaCalculator' is not up-to-date");
+
+			String addJavaAfter = FileUtils.readFileToString(
+					new File(runner.getProjectDir(), "build/generated-sources/org/tempuri/Add.java"), "UTF-8");
+			assertThat(addJavaAfter).contains("protected int intC;");
+		}
+		{
+			// test that a change just in the referenced XSD triggers a rebuild
+			GradleRunner runner = gradleBuild.prepareRunner("wsdl2javaCalculator", "-i");
+			runner.build();
+
+			String addJavaBefore = FileUtils.readFileToString(
+					new File(runner.getProjectDir(), "build/generated-sources/org/tempuri/Add.java"), "UTF-8");
+			assertThat(addJavaBefore).doesNotContain("protected int intC;");
+
+			FileUtils.copyFile(new File("src/functionalTest/resources/wsdls/calculatorModified.xsd"),
+					new File(runner.getProjectDir(), "wsdls/calculator.xsd"));
+
+			BuildResult finalResult = runner.build();
+			assertThat(finalResult.getOutput()).contains("Task ':wsdl2javaCalculator' is not up-to-date");
+
+			String addJavaAfter = FileUtils.readFileToString(
+					new File(runner.getProjectDir(), "build/generated-sources/org/tempuri/Add.java"), "UTF-8");
+			assertThat(addJavaAfter).contains("protected int intC;");
+		}
 	}
 
 	@TestTemplate
 	void generatesJavaFromWsdl(GradleBuild gradleBuild) {
-		doTest(gradleBuild);
-	}
-
-	void doTest(GradleBuild gradleBuild) {
 		GradleRunner runner = gradleBuild.prepareRunner("wsdl2javaCalculator", "-i");
 
 		BuildResult initialResult = runner.build();
-		BuildResult secondResult = runner.build();
-		BuildResult finalResult = runner.build();
-
 		assertThat(initialResult.getOutput()).contains("Task ':wsdl2javaCalculator' is not up-to-date");
+		BuildResult secondResult = runner.build();
 		assertThat(secondResult.getOutput()).contains("Skipping task ':wsdl2javaCalculator' as it is up-to-date.");
-		assertThat(finalResult.getOutput()).contains("Skipping task ':wsdl2javaCalculator' as it is up-to-date.");
+		Map<String, String> env = new HashMap<>();
+		env.put("MARK_GENERATED", "1");
+		BuildResult finalResult = runner.withEnvironment(env).build();
+		// test that WSDLOption changes actually trigger a rebuild
+		assertThat(finalResult.getOutput()).contains("Task ':wsdl2javaCalculator' is not up-to-date");
 	}
 
 }

--- a/cxf-codegen-gradle/src/functionalTest/java/io/mateo/junit/GradleBuild.java
+++ b/cxf-codegen-gradle/src/functionalTest/java/io/mateo/junit/GradleBuild.java
@@ -70,7 +70,7 @@ public class GradleBuild {
 
 	public BuildResult build(String... arguments) {
 		try {
-			return prepareRunner(arguments).build();
+			return prepareRunnerDebug(arguments).build();
 		}
 		catch (Exception ex) {
 			throw new RuntimeException(ex);
@@ -79,7 +79,7 @@ public class GradleBuild {
 
 	public BuildResult buildAndFail(String... arguments) {
 		try {
-			return prepareRunner(arguments).buildAndFail();
+			return prepareRunnerDebug(arguments).buildAndFail();
 		}
 		catch (Exception ex) {
 			throw new RuntimeException(ex);
@@ -116,11 +116,16 @@ public class GradleBuild {
 		}
 
 		GradleRunner gradleRunner = GradleRunner.create().withProjectDir(this.projectDir).withPluginClasspath();
-		gradleRunner.withDebug(true);
 		if (this.gradleVersion != null) {
 			gradleRunner.withGradleVersion(this.gradleVersion);
 		}
 		return gradleRunner.withArguments(List.of(arguments));
+	}
+
+	public GradleRunner prepareRunnerDebug(String... arguments) {
+		GradleRunner runner = prepareRunner(arguments);
+		runner.withDebug(true);
+		return runner;
 	}
 
 	public GradleBuild gradleVersion(String version) {

--- a/cxf-codegen-gradle/src/functionalTest/resources/io/mateo/cxf/codegen/configurationCache.gradle
+++ b/cxf-codegen-gradle/src/functionalTest/resources/io/mateo/cxf/codegen/configurationCache.gradle
@@ -13,7 +13,7 @@ dependencies {
 }
 
 cxfCodegen {
-    wsdl2java.configure {
+    wsdl2java {
         calculator {
             wsdl = file("wsdls/calculator.wsdl")
         }

--- a/cxf-codegen-gradle/src/functionalTest/resources/io/mateo/cxf/codegen/failForMissingWsdl.gradle
+++ b/cxf-codegen-gradle/src/functionalTest/resources/io/mateo/cxf/codegen/failForMissingWsdl.gradle
@@ -8,7 +8,7 @@ repositories {
 }
 
 cxfCodegen {
-    wsdl2java.configure {
+    wsdl2java {
         calculator
     }
 }

--- a/cxf-codegen-gradle/src/functionalTest/resources/io/mateo/cxf/codegen/generatesJavaFromWsdl.gradle
+++ b/cxf-codegen-gradle/src/functionalTest/resources/io/mateo/cxf/codegen/generatesJavaFromWsdl.gradle
@@ -11,12 +11,11 @@ dependencies {
     cxfCodegen "jakarta.xml.ws:jakarta.xml.ws-api:2.3.3"
     cxfCodegen "jakarta.annotation:jakarta.annotation-api:1.3.5"
 }
-
 cxfCodegen {
-    wsdl2java.configure {
+    wsdl2java {
         calculator {
             wsdl.set(file("wsdls/calculator.wsdl"))
-            markGenerated.set(false)
+            markGenerated = System.getenv("MARK_GENERATED") ? true : false
         }
     }
 }

--- a/cxf-codegen-gradle/src/functionalTest/resources/io/mateo/cxf/codegen/generatesJavaFromWsdl.gradle.kts
+++ b/cxf-codegen-gradle/src/functionalTest/resources/io/mateo/cxf/codegen/generatesJavaFromWsdl.gradle.kts
@@ -16,7 +16,7 @@ cxfCodegen {
     wsdl2java {
         register("calculator") {
             wsdl.set(file("wsdls/calculator.wsdl"))
-            markGenerated.set(false)
+            markGenerated.set(if (System.getenv("MARK_GENERATED").isNullOrEmpty()) false else true )
         }
     }
 }

--- a/cxf-codegen-gradle/src/functionalTest/resources/io/mateo/cxf/codegen/separateXsd.gradle
+++ b/cxf-codegen-gradle/src/functionalTest/resources/io/mateo/cxf/codegen/separateXsd.gradle
@@ -13,7 +13,7 @@ dependencies {
 }
 
 cxfCodegen {
-    wsdl2java.configure {
+    wsdl2java {
         calculator {
             wsdl.set(file("wsdls/calculatorSeparateXsd.wsdl"))
         }

--- a/cxf-codegen-gradle/src/functionalTest/resources/wsdls/calculatorModified.xsd
+++ b/cxf-codegen-gradle/src/functionalTest/resources/wsdls/calculatorModified.xsd
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<s:schema version="1.0" targetNamespace="http://tempuri.org/" xmlns:tns="http://tempuri.org/" xmlns:s="http://www.w3.org/2001/XMLSchema">
+    <s:element name="Add">
+        <s:complexType>
+            <s:sequence>
+                <s:element minOccurs="1" maxOccurs="1" name="intA" type="s:int"/>
+                <s:element minOccurs="1" maxOccurs="1" name="intB" type="s:int"/>
+                <s:element minOccurs="1" maxOccurs="1" name="intC" type="s:int"/>
+            </s:sequence>
+        </s:complexType>
+    </s:element>
+    <s:element name="AddResponse">
+        <s:complexType>
+            <s:sequence>
+                <s:element minOccurs="1" maxOccurs="1" name="AddResult" type="s:int"/>
+            </s:sequence>
+        </s:complexType>
+    </s:element>
+    <s:element name="Subtract">
+        <s:complexType>
+            <s:sequence>
+                <s:element minOccurs="1" maxOccurs="1" name="intA" type="s:int"/>
+                <s:element minOccurs="1" maxOccurs="1" name="intB" type="s:int"/>
+            </s:sequence>
+        </s:complexType>
+    </s:element>
+    <s:element name="SubtractResponse">
+        <s:complexType>
+            <s:sequence>
+                <s:element minOccurs="1" maxOccurs="1" name="SubtractResult" type="s:int"/>
+            </s:sequence>
+        </s:complexType>
+    </s:element>
+    <s:element name="Multiply">
+        <s:complexType>
+            <s:sequence>
+                <s:element minOccurs="1" maxOccurs="1" name="intA" type="s:int"/>
+                <s:element minOccurs="1" maxOccurs="1" name="intB" type="s:int"/>
+            </s:sequence>
+        </s:complexType>
+    </s:element>
+    <s:element name="MultiplyResponse">
+        <s:complexType>
+            <s:sequence>
+                <s:element minOccurs="1" maxOccurs="1" name="MultiplyResult" type="s:int"/>
+            </s:sequence>
+        </s:complexType>
+    </s:element>
+    <s:element name="Divide">
+        <s:complexType>
+            <s:sequence>
+                <s:element minOccurs="1" maxOccurs="1" name="intA" type="s:int"/>
+                <s:element minOccurs="1" maxOccurs="1" name="intB" type="s:int"/>
+            </s:sequence>
+        </s:complexType>
+    </s:element>
+    <s:element name="DivideResponse">
+        <s:complexType>
+            <s:sequence>
+                <s:element minOccurs="1" maxOccurs="1" name="DivideResult" type="s:int"/>
+            </s:sequence>
+        </s:complexType>
+    </s:element>
+</s:schema>

--- a/cxf-codegen-gradle/src/functionalTest/resources/wsdls/calculatorSeparateXsdModified.wsdl
+++ b/cxf-codegen-gradle/src/functionalTest/resources/wsdls/calculatorSeparateXsdModified.wsdl
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tm="http://microsoft.com/wsdl/mime/textMatching/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:tns="http://tempuri.org/" xmlns:s="http://www.w3.org/2001/XMLSchema" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" targetNamespace="http://tempuri.org/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+  <wsdl:types>
+    <s:schema>
+      <s:import namespace="http://tempuri.org/" schemaLocation="calculatorModified.xsd" />
+    </s:schema>
+  </wsdl:types>
+  <wsdl:message name="AddSoapIn">
+    <wsdl:part name="parameters" element="tns:Add"/>
+  </wsdl:message>
+  <wsdl:message name="AddSoapOut">
+    <wsdl:part name="parameters" element="tns:AddResponse"/>
+  </wsdl:message>
+  <wsdl:message name="SubtractSoapIn">
+    <wsdl:part name="parameters" element="tns:Subtract"/>
+  </wsdl:message>
+  <wsdl:message name="SubtractSoapOut">
+    <wsdl:part name="parameters" element="tns:SubtractResponse"/>
+  </wsdl:message>
+  <wsdl:message name="MultiplySoapIn">
+    <wsdl:part name="parameters" element="tns:Multiply"/>
+  </wsdl:message>
+  <wsdl:message name="MultiplySoapOut">
+    <wsdl:part name="parameters" element="tns:MultiplyResponse"/>
+  </wsdl:message>
+  <wsdl:message name="DivideSoapIn">
+    <wsdl:part name="parameters" element="tns:Divide"/>
+  </wsdl:message>
+  <wsdl:message name="DivideSoapOut">
+    <wsdl:part name="parameters" element="tns:DivideResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="CalculatorSoap">
+    <wsdl:operation name="Add">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Adds two integers. This is a test WebService. ©DNE Online</wsdl:documentation>
+      <wsdl:input message="tns:AddSoapIn"/>
+      <wsdl:output message="tns:AddSoapOut"/>
+    </wsdl:operation>
+    <wsdl:operation name="Subtract">
+      <wsdl:input message="tns:SubtractSoapIn"/>
+      <wsdl:output message="tns:SubtractSoapOut"/>
+    </wsdl:operation>
+    <wsdl:operation name="Multiply">
+      <wsdl:input message="tns:MultiplySoapIn"/>
+      <wsdl:output message="tns:MultiplySoapOut"/>
+    </wsdl:operation>
+    <wsdl:operation name="Divide">
+      <wsdl:input message="tns:DivideSoapIn"/>
+      <wsdl:output message="tns:DivideSoapOut"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="CalculatorSoap" type="tns:CalculatorSoap">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="Add">
+      <soap:operation soapAction="http://tempuri.org/Add" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="Subtract">
+      <soap:operation soapAction="http://tempuri.org/Subtract" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="Multiply">
+      <soap:operation soapAction="http://tempuri.org/Multiply" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="Divide">
+      <soap:operation soapAction="http://tempuri.org/Divide" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:binding name="CalculatorSoap12" type="tns:CalculatorSoap">
+    <soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="Add">
+      <soap12:operation soapAction="http://tempuri.org/Add" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="Subtract">
+      <soap12:operation soapAction="http://tempuri.org/Subtract" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="Multiply">
+      <soap12:operation soapAction="http://tempuri.org/Multiply" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="Divide">
+      <soap12:operation soapAction="http://tempuri.org/Divide" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="Calculator">
+    <wsdl:port name="CalculatorSoap" binding="tns:CalculatorSoap">
+      <soap:address location="http://www.dneonline.com/calculator.asmx"/>
+    </wsdl:port>
+    <wsdl:port name="CalculatorSoap12" binding="tns:CalculatorSoap12">
+      <soap12:address location="http://www.dneonline.com/calculator.asmx"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/cxf-codegen-gradle/src/main/java/io/mateo/cxf/codegen/wsdl2java/Wsdl2JavaTask.java
+++ b/cxf-codegen-gradle/src/main/java/io/mateo/cxf/codegen/wsdl2java/Wsdl2JavaTask.java
@@ -15,18 +15,117 @@
  */
 package io.mateo.cxf.codegen.wsdl2java;
 
-import javax.inject.Inject;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.Vector;
 
-import org.gradle.api.tasks.JavaExec;
+import javax.inject.Inject;
+import javax.wsdl.Definition;
+import javax.wsdl.Import;
+import javax.wsdl.WSDLException;
+import javax.wsdl.extensions.schema.Schema;
+import javax.wsdl.extensions.schema.SchemaReference;
+import javax.wsdl.factory.WSDLFactory;
+import javax.wsdl.xml.WSDLReader;
+
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.tasks.*;
 
 /**
  * Generates Java sources from WSDLs.
  */
+@CacheableTask
 public class Wsdl2JavaTask extends JavaExec {
 
+	private static Set<Definition> getReferencedDefinitions(Definition definition) {
+		Set<Definition> definitions = new HashSet<>();
+		definitions.add(definition);
+		for (Object wsdlImports : definition.getImports().values()) {
+			if (wsdlImports instanceof Collection) {
+				for (Object wsdlImport : (Collection) wsdlImports) {
+					if (wsdlImport instanceof Import) {
+						definitions.addAll(getReferencedDefinitions(((Import) wsdlImport).getDefinition()));
+					}
+				}
+			}
+		}
+		return definitions;
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	private static Set<Schema> getReferencedSchemas(Schema schema) {
+
+		Set<Schema> schemas = new HashSet<>();
+		schemas.add(schema);
+
+		Set<Object> references = new HashSet(schema.getIncludes());
+		references.addAll(schema.getImports().values());
+
+		for (Object refs : references) {
+			if (refs instanceof Vector) {
+				for (Object reference : (Vector) refs) {
+					if (reference instanceof SchemaReference) {
+						schemas.addAll(getReferencedSchemas(((SchemaReference) reference).getReferencedSchema()));
+					}
+				}
+			}
+		}
+		return schemas;
+	}
+
+	public static ConfigurableFileCollection sourceFiles(RegularFileProperty wsdl, ObjectFactory objectFactory)
+			throws WSDLException {
+		ConfigurableFileCollection collection = objectFactory.fileCollection();
+		WSDLReader wsdlReader = WSDLFactory.newInstance().newWSDLReader();
+		wsdlReader.setFeature("javax.wsdl.verbose", false);
+		Definition rootDefinition = wsdlReader.readWSDL(wsdl.get().getAsFile().getAbsolutePath());
+		Set<Definition> definitions = getReferencedDefinitions(rootDefinition);
+		Set<Schema> schemas = new HashSet<>();
+		for (Definition definition : definitions) {
+			for (Object ext : definition.getTypes().getExtensibilityElements()) {
+				if (ext instanceof Schema) {
+					schemas.addAll(getReferencedSchemas((Schema) ext));
+				}
+			}
+		}
+		for (Definition definition : definitions) {
+			collection.from(definition.getDocumentBaseURI());
+		}
+		for (Schema schema : schemas) {
+			collection.from(schema.getDocumentBaseURI());
+		}
+		return collection;
+	}
+
+	private final ObjectFactory objectFactory;
+
+	private final RegularFileProperty source;
+
 	@Inject
-	public Wsdl2JavaTask() {
+	public Wsdl2JavaTask(ObjectFactory objectFactory) {
 		super();
+		this.objectFactory = objectFactory;
+		this.source = objectFactory.fileProperty();
+	}
+
+	@Internal
+	public RegularFileProperty getSource() {
+		return this.source;
+	}
+
+	@InputFiles
+	@PathSensitive(PathSensitivity.RELATIVE)
+	public ConfigurableFileCollection getInputFiles() {
+		try {
+			return sourceFiles(this.source, this.objectFactory);
+		}
+		catch (WSDLException e) {
+			e.printStackTrace();
+		}
+		return null;
 	}
 
 }

--- a/cxf-codegen-gradle/src/test/java/io/mateo/cxf/codegen/CxfCodegenPluginTests.java
+++ b/cxf-codegen-gradle/src/test/java/io/mateo/cxf/codegen/CxfCodegenPluginTests.java
@@ -140,8 +140,8 @@ class CxfCodegenPluginTests {
 		assertThatCode(() -> wsdl2Java.getClasspath().getFiles()).hasMessageContaining("configuration ':cxfCodegen'");
 		assertThat(wsdl2Java.getGroup()).isEqualTo(CxfCodegenPlugin.WSDL2JAVA_GROUP);
 		assertThat(wsdl2Java.getDescription()).isEqualTo(String.format("Generates Java sources for '%s'", sourceName));
-		assertThat(wsdl2Java.getTaskActions()).hasSize(2).first().extracting(Describable::getDisplayName).asString()
-				.contains("Execute generateArgsFor");
+		assertThat(wsdl2Java.getTaskActions()).hasSize(1).first().extracting(Describable::getDisplayName).asString()
+				.contains("Execute exec");
 	}
 
 }


### PR DESCRIPTION
Hey, that's my attempt for #13 
The tests now run and I added 2 new tests (incremental builds for any input, e.g. WSDLOption properties, for changes in the WSDL and for changes just in referenced XSDs).

I pulled task registration and sourceSet modification in the extension to be able to remove the setArgs extra task action, while hopefully preventing #7.
As I mentioned earlier, I couldn't get `wsdl2java.configure` creating a `WSDLOption` element to work properly in the Groovy DSL.
Likewise, in manual testing `wsdl2java.configureAll` doesn't work correctly, however e.g. `wsdl2java.all { markGenerated = true }` does work. I never used the Groovy DSL though, so I don't know what's idiomatic.
I think that belongs together as otherwise, the task would react *just* on changes in the WSDLs. Changing any other options would not trigger an incremental rebuild, and the cache key for the build cache will still be wrong (e.g. markGenerated = false and markGenerated = true would have the same cache key, so if the build cache is used you always get the same code, depending on the option set during the first build).

Please take a look.