### PR TITLE
Add test for incremental build behaviour on changes

### DIFF
--- a/cxf-codegen-gradle/src/functionalTest/java/io/mateo/cxf/codegen/IncrementalBuildFunctionalTests.java
+++ b/cxf-codegen-gradle/src/functionalTest/java/io/mateo/cxf/codegen/IncrementalBuildFunctionalTests.java
@@ -17,9 +17,14 @@ package io.mateo.cxf.codegen;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.File;
+import java.io.IOException;
+
 import io.mateo.junit.GradleBuild;
 import io.mateo.junit.GradleCompatibility;
+import io.mateo.junit.GradleDsl;
 
+import org.apache.commons.io.FileUtils;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.TestTemplate;
@@ -27,26 +32,53 @@ import org.junit.jupiter.api.TestTemplate;
 @GradleCompatibility
 class IncrementalBuildFunctionalTests {
 
+	private void overwriteBuildSpec(GradleBuild build, String newBuildFileBase) throws IOException {
+		if (build.getDsl() == GradleDsl.GROOVY) {
+			FileUtils.copyFile(
+					new File("src/functionalTest/resources/io/mateo/cxf/codegen", newBuildFileBase + ".gradle"),
+					new File(build.getProjectDir(), "build.gradle"));
+		}
+		else {
+			FileUtils.copyFile(
+					new File("src/functionalTest/resources/io/mateo/cxf/codegen", newBuildFileBase + ".gradle.kts"),
+					new File(build.getProjectDir(), "build.gradle.kts"));
+		}
+
+	}
+
 	@TestTemplate
 	void separateXsd(GradleBuild gradleBuild) {
-		doTest(gradleBuild);
+		GradleRunner runner = gradleBuild.prepareRunner("wsdl2javaCalculator", "-i");
+		BuildResult initial = runner.build();
+		assertThat(initial.getOutput()).contains("Task ':wsdl2javaCalculator' is not up-to-date");
+		BuildResult second = runner.build();
+		assertThat(second.getOutput()).contains("Skipping task ':wsdl2javaCalculator' as it is up-to-date.");
+		BuildResult third = runner.build();
+		assertThat(third.getOutput()).contains("Skipping task ':wsdl2javaCalculator' as it is up-to-date.");
 	}
 
 	@TestTemplate
-	void generatesJavaFromWsdl(GradleBuild gradleBuild) {
-		doTest(gradleBuild);
-	}
-
-	void doTest(GradleBuild gradleBuild) {
+	void generatesJavaFromWsdl(GradleBuild gradleBuild) throws IOException {
 		GradleRunner runner = gradleBuild.prepareRunner("wsdl2javaCalculator", "-i");
 
-		BuildResult initialResult = runner.build();
-		BuildResult secondResult = runner.build();
-		BuildResult finalResult = runner.build();
+		BuildResult first = runner.build();
+		assertThat(first.getOutput()).contains("Task ':wsdl2javaCalculator' is not up-to-date");
+		BuildResult second = runner.build();
+		assertThat(second.getOutput()).contains("Skipping task ':wsdl2javaCalculator' as it is up-to-date.");
 
-		assertThat(initialResult.getOutput()).contains("Task ':wsdl2javaCalculator' is not up-to-date");
-		assertThat(secondResult.getOutput()).contains("Skipping task ':wsdl2javaCalculator' as it is up-to-date.");
-		assertThat(finalResult.getOutput()).contains("Skipping task ':wsdl2javaCalculator' as it is up-to-date.");
+		// test that changing WSDLOption.markGenerated triggers a rebuild
+		this.overwriteBuildSpec(gradleBuild, "generatesJavaFromWsdlChangedMarkGenerated");
+		BuildResult third = runner.build();
+		assertThat(third.getOutput()).contains("Task ':wsdl2javaCalculator' is not up-to-date");
+		BuildResult fourth = runner.build();
+		assertThat(fourth.getOutput()).contains("Skipping task ':wsdl2javaCalculator' as it is up-to-date.");
+
+		// test that changing WsdlOption.wsdl triggers a rebuild
+		this.overwriteBuildSpec(gradleBuild, "generatesJavaFromWsdlChangedWsdl");
+		BuildResult fifth = runner.build();
+		assertThat(fifth.getOutput()).contains("Task ':wsdl2javaCalculator' is not up-to-date");
+		BuildResult sixth = runner.build();
+		assertThat(sixth.getOutput()).contains("Skipping task ':wsdl2javaCalculator' as it is up-to-date.");
 	}
 
 }

--- a/cxf-codegen-gradle/src/functionalTest/resources/io/mateo/cxf/codegen/generatesJavaFromWsdlChangedMarkGenerated.gradle
+++ b/cxf-codegen-gradle/src/functionalTest/resources/io/mateo/cxf/codegen/generatesJavaFromWsdlChangedMarkGenerated.gradle
@@ -15,7 +15,7 @@ cxfCodegen {
     wsdl2java.configure {
         calculator {
             wsdl.set(file("wsdls/calculator.wsdl"))
-            markGenerated = false
+            markGenerated = true
         }
     }
 }

--- a/cxf-codegen-gradle/src/functionalTest/resources/io/mateo/cxf/codegen/generatesJavaFromWsdlChangedMarkGenerated.gradle.kts
+++ b/cxf-codegen-gradle/src/functionalTest/resources/io/mateo/cxf/codegen/generatesJavaFromWsdlChangedMarkGenerated.gradle.kts
@@ -1,0 +1,22 @@
+plugins {
+    java
+    id("io.mateo.cxf-codegen")
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    cxfCodegen("jakarta.xml.ws:jakarta.xml.ws-api:2.3.3")
+    cxfCodegen("jakarta.annotation:jakarta.annotation-api:1.3.5")
+}
+
+cxfCodegen {
+    wsdl2java {
+        register("calculator") {
+            wsdl.set(file("wsdls/calculator.wsdl"))
+            markGenerated.set(true)
+        }
+    }
+}

--- a/cxf-codegen-gradle/src/functionalTest/resources/io/mateo/cxf/codegen/generatesJavaFromWsdlChangedWsdl.gradle
+++ b/cxf-codegen-gradle/src/functionalTest/resources/io/mateo/cxf/codegen/generatesJavaFromWsdlChangedWsdl.gradle
@@ -14,7 +14,7 @@ dependencies {
 cxfCodegen {
     wsdl2java.configure {
         calculator {
-            wsdl.set(file("wsdls/calculator.wsdl"))
+            wsdl = file("wsdls/calculatorCopy.wsdl")
             markGenerated = false
         }
     }

--- a/cxf-codegen-gradle/src/functionalTest/resources/io/mateo/cxf/codegen/generatesJavaFromWsdlChangedWsdl.gradle.kts
+++ b/cxf-codegen-gradle/src/functionalTest/resources/io/mateo/cxf/codegen/generatesJavaFromWsdlChangedWsdl.gradle.kts
@@ -1,0 +1,22 @@
+plugins {
+    java
+    id("io.mateo.cxf-codegen")
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    cxfCodegen("jakarta.xml.ws:jakarta.xml.ws-api:2.3.3")
+    cxfCodegen("jakarta.annotation:jakarta.annotation-api:1.3.5")
+}
+
+cxfCodegen {
+    wsdl2java {
+        register("calculator") {
+            wsdl.set(file("wsdls/calculatorCopy.wsdl"))
+            markGenerated.set(false)
+        }
+    }
+}

--- a/cxf-codegen-gradle/src/functionalTest/resources/wsdls/calculatorCopy.wsdl
+++ b/cxf-codegen-gradle/src/functionalTest/resources/wsdls/calculatorCopy.wsdl
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tm="http://microsoft.com/wsdl/mime/textMatching/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:tns="http://tempuri.org/" xmlns:s="http://www.w3.org/2001/XMLSchema" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" targetNamespace="http://tempuri.org/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+  <wsdl:types>
+    <s:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/">
+      <s:element name="Add">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="1" maxOccurs="1" name="intA" type="s:int"/>
+            <s:element minOccurs="1" maxOccurs="1" name="intB" type="s:int"/>
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="AddResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="1" maxOccurs="1" name="AddResult" type="s:int"/>
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="Subtract">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="1" maxOccurs="1" name="intA" type="s:int"/>
+            <s:element minOccurs="1" maxOccurs="1" name="intB" type="s:int"/>
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="SubtractResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="1" maxOccurs="1" name="SubtractResult" type="s:int"/>
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="Multiply">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="1" maxOccurs="1" name="intA" type="s:int"/>
+            <s:element minOccurs="1" maxOccurs="1" name="intB" type="s:int"/>
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="MultiplyResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="1" maxOccurs="1" name="MultiplyResult" type="s:int"/>
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="Divide">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="1" maxOccurs="1" name="intA" type="s:int"/>
+            <s:element minOccurs="1" maxOccurs="1" name="intB" type="s:int"/>
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="DivideResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="1" maxOccurs="1" name="DivideResult" type="s:int"/>
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+    </s:schema>
+  </wsdl:types>
+  <wsdl:message name="AddSoapIn">
+    <wsdl:part name="parameters" element="tns:Add"/>
+  </wsdl:message>
+  <wsdl:message name="AddSoapOut">
+    <wsdl:part name="parameters" element="tns:AddResponse"/>
+  </wsdl:message>
+  <wsdl:message name="SubtractSoapIn">
+    <wsdl:part name="parameters" element="tns:Subtract"/>
+  </wsdl:message>
+  <wsdl:message name="SubtractSoapOut">
+    <wsdl:part name="parameters" element="tns:SubtractResponse"/>
+  </wsdl:message>
+  <wsdl:message name="MultiplySoapIn">
+    <wsdl:part name="parameters" element="tns:Multiply"/>
+  </wsdl:message>
+  <wsdl:message name="MultiplySoapOut">
+    <wsdl:part name="parameters" element="tns:MultiplyResponse"/>
+  </wsdl:message>
+  <wsdl:message name="DivideSoapIn">
+    <wsdl:part name="parameters" element="tns:Divide"/>
+  </wsdl:message>
+  <wsdl:message name="DivideSoapOut">
+    <wsdl:part name="parameters" element="tns:DivideResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="CalculatorSoap">
+    <wsdl:operation name="Add">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Adds two integers. This is a test WebService. ©DNE Online</wsdl:documentation>
+      <wsdl:input message="tns:AddSoapIn"/>
+      <wsdl:output message="tns:AddSoapOut"/>
+    </wsdl:operation>
+    <wsdl:operation name="Subtract">
+      <wsdl:input message="tns:SubtractSoapIn"/>
+      <wsdl:output message="tns:SubtractSoapOut"/>
+    </wsdl:operation>
+    <wsdl:operation name="Multiply">
+      <wsdl:input message="tns:MultiplySoapIn"/>
+      <wsdl:output message="tns:MultiplySoapOut"/>
+    </wsdl:operation>
+    <wsdl:operation name="Divide">
+      <wsdl:input message="tns:DivideSoapIn"/>
+      <wsdl:output message="tns:DivideSoapOut"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="CalculatorSoap" type="tns:CalculatorSoap">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="Add">
+      <soap:operation soapAction="http://tempuri.org/Add" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="Subtract">
+      <soap:operation soapAction="http://tempuri.org/Subtract" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="Multiply">
+      <soap:operation soapAction="http://tempuri.org/Multiply" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="Divide">
+      <soap:operation soapAction="http://tempuri.org/Divide" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:binding name="CalculatorSoap12" type="tns:CalculatorSoap">
+    <soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="Add">
+      <soap12:operation soapAction="http://tempuri.org/Add" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="Subtract">
+      <soap12:operation soapAction="http://tempuri.org/Subtract" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="Multiply">
+      <soap12:operation soapAction="http://tempuri.org/Multiply" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="Divide">
+      <soap12:operation soapAction="http://tempuri.org/Divide" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="Calculator">
+    <wsdl:port name="CalculatorSoap" binding="tns:CalculatorSoap">
+      <soap:address location="http://www.dneonline.com/calculator.asmx"/>
+    </wsdl:port>
+    <wsdl:port name="CalculatorSoap12" binding="tns:CalculatorSoap12">
+      <soap12:address location="http://www.dneonline.com/calculator.asmx"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION
As requested, tests for incremental build behavior (#7, #18)
They fail at 5ce5eca53df0fc4fbabffe7176f2c4a0a039e6dd, but succeed at 8f814c2fdfec09cabd83e5f95603245c0a5c132f, so it looks like the latest commit fixes the incremental build being always up-to-date issue.